### PR TITLE
Changed SASS include paths to be explicitly configured

### DIFF
--- a/Baboon.Angular.App/environment.config.js
+++ b/Baboon.Angular.App/environment.config.js
@@ -86,7 +86,12 @@ module.exports = {
 		//don't add bootstrap in here (it's included as part of the bootstrap-sass build pipeline)
 		'bower_components/angular-toastr/dist/angular-toastr.min.css'
     ],
-	
+
+    //explicitly list any folders that you want to @import in your sass code
+    sassIncludeDirectories: [
+        './bower_components/bootstrap-sass/assets/stylesheets'
+    ],
+    
 	//explicit list of included vendor font dependencies
 	fonts: [
         'bower_components/**/*.woff',

--- a/Baboon.Angular.App/gulp tasks/dev build tasks.js
+++ b/Baboon.Angular.App/gulp tasks/dev build tasks.js
@@ -41,7 +41,7 @@ gulp.task('dev:fonts', ['clean:fonts'], function () {
 gulp.task('dev:css', ['clean:css'], function () {
     return gulp.src([environment.sourceDirectory + '/**/*.scss', environment.commonDirectory + '/common/**/*.scss'])
         .pipe(sass({
-            includePaths: [environment.bootstrapDirectory + '/assets/stylesheets'],
+            includePaths: environment.sassIncludeDirectories,
         }))
         .pipe(gulp.dest(environment.buildDirectory + '/css/app/'))
         .on('error', gutil.log);;

--- a/Baboon.Angular.App/gulp tasks/style guide tasks.js
+++ b/Baboon.Angular.App/gulp tasks/style guide tasks.js
@@ -30,7 +30,7 @@ gulp.task('styleguide:css', [], function () {
     var vendorSource = gulp.src(environment.vendorCssFiles);
     var customSource = gulp.src([environment.sourceDirectory + '/**/*.scss', environment.commonDirectory + '/common/**/*.scss'])
         .pipe(sass({
-            includePaths: [environment.bootstrapDirectory + '/assets/stylesheets'],
+            includePaths: environment.sassIncludeDirectories
         }));
 
     return es.merge(vendorSource, customSource)

--- a/Baboon.Angular.App/gulp tasks/watching tasks.js
+++ b/Baboon.Angular.App/gulp tasks/watching tasks.js
@@ -38,7 +38,7 @@ gulp.task('watch:css', function () {
         return gulp.src(glob)
             .pipe(cache('css'))
             .pipe(sass({
-                includePaths: [environment.bootstrapDirectory + '/assets/stylesheets'],
+                includePaths: environment.sassIncludeDirectories
             }))
             .pipe(remember('css'))
             .pipe(gulp.dest(environment.distributionDirectory + '/css/app/'))

--- a/Baboon.Angular.App/src/app.scss
+++ b/Baboon.Angular.App/src/app.scss
@@ -1,2 +1,4 @@
+$icon-font-path: "../../fonts/";
+
 @import "bootstrap";
 @import "bootstrap/theme";


### PR DESCRIPTION
The benefit to this is that you can add other sass libraries.

Example use case: I included font-awesome in my project. I needed to
include the SASS version so that I could override the path to the font
files.

Something else that I did while testing was fix bootstrap's $icon-font-path variable so that it can load the glyphicon fonts correctly.