### PR TITLE
Added npm scripts to ease development workflow

### DIFF
--- a/Baboon.Angular.App/package.json
+++ b/Baboon.Angular.App/package.json
@@ -4,7 +4,9 @@
   "description": "Entelect Angular 1.4.0 Seed Project",
   "main": "index.js",
   "scripts": {
-    "test": "test"
+    "postinstall": "bower install",
+    "test": "gulp",
+    "start": "gulp watch & http-server dist"
   },
   "keywords": [
     "Entelect"
@@ -60,7 +62,8 @@
     "require-dir": "^0.3.0",
     "run-sequence": "^1.1.4",
     "swagger-parser": "^3.3.0",
-    "uglify-js": "~2.4.19"
+    "uglify-js": "~2.4.19",
+    "http-server": "~0.8.5"
   },
   "devDependencies": {
     "gulp-angular-filesort": "^1.1.1"


### PR DESCRIPTION
Usage:
* `npm install` to install both npm and bower packages
* `npm test` to do once off build and test
* `npm start` to gulp watch and start a web server watching the directory

I've found this to be a huge benefit when simplifying CI build
configurations. Something that isn't obvious is that bower and gulp
don't actually need to be on the path for these scripts to work. npm
will check for the ones installed during the npm install step.  This
also helps in getting new devs up and running, since there are less
global dependencies for them to install.