### PR TITLE
Fixed templates being duplicated in release build

### DIFF
--- a/Baboon.Angular.App/gulp tasks/release tasks.js
+++ b/Baboon.Angular.App/gulp tasks/release tasks.js
@@ -39,7 +39,8 @@ gulp.task('release:js', ['dev:js', 'dev:config'], function () {
     return gulp.src([
         environment.buildDirectory + '/js/app/**/*.module.js',
         environment.buildDirectory + '/js/app/**/*.config.js',
-        environment.buildDirectory + '/js/app/**/*'
+        environment.buildDirectory + '/js/app/**/*',
+        '!' + environment.buildDirectory + '/js/app/templates**/*.js'
     ])
         .pipe(concat('app.js'))
         .pipe(ngAnnotate(annotationConfig))


### PR DESCRIPTION
I discovered an issue where the templates were being included in both the `app.min.js` and `templates.min.js` file when doing a release build.

This fix just takes the templates out of the `app.min.js` file.
